### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'docs/**'
 
+permissions:
+  contents: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NexusDI/core/security/code-scanning/9](https://github.com/NexusDI/core/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow involves deploying documentation, it likely requires `contents: write` to push the built documentation to the repository. Other permissions will be set to `read` or omitted entirely if not needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
